### PR TITLE
Remove `context = null` 

### DIFF
--- a/android/src/main/java/com/rmawatson/flutterisolate/FlutterIsolatePlugin.java
+++ b/android/src/main/java/com/rmawatson/flutterisolate/FlutterIsolatePlugin.java
@@ -214,8 +214,6 @@ public class FlutterIsolatePlugin implements FlutterPlugin, MethodCallHandler, S
                 activeIsolates.get(isolateId).engine.destroy();
             activeIsolates.remove(isolateId);
 
-            context = null;
-
         } else {
             result.notImplemented();
         }


### PR DESCRIPTION
Hi,
The 'context = null' caused below issue:
Exception occured when you create a new isolate once you killed one before. 
```
Exception has occurred.
PlatformException (PlatformException(error, Attempt to invoke virtual method 'android.content.Context android.content.Context.getApplicationContext()' on a null object reference, null))
```
