### PR TITLE
Fix bug where isolates sometimes don't start.

### DIFF
--- a/ios/Classes/FlutterIsolatePlugin.m
+++ b/ios/Classes/FlutterIsolatePlugin.m
@@ -4,7 +4,7 @@
 @interface IsolateHolder : NSObject
 @property(nonatomic) FlutterEngine* engine;
 @property(nonatomic) NSString* isolateId;
-@property(nonatomic) long entryPoint;
+@property(nonatomic) long long entryPoint;
 @property(nonatomic) FlutterResult result;
 @property(nonatomic) FlutterEventChannel* startupChannel;
 @property(nonatomic) FlutterMethodChannel* controlChannel;
@@ -109,7 +109,7 @@ static FlutterIsolatePlugin* instance = nil;
   if ([@"spawn_isolate" isEqualToString:call.method]) {
       IsolateHolder* isolate = [IsolateHolder new];
 
-      isolate.entryPoint = [[call.arguments objectForKey:@"entry_point"] longValue];
+      isolate.entryPoint = [[call.arguments objectForKey:@"entry_point"] longLongValue];
       isolate.isolateId = [call.arguments objectForKey:@"isolate_id"];
       isolate.result = result;
 


### PR DESCRIPTION
Raw callback handles can be 64 bits, and the long type in objective c is
only 32 bits. This leads to weird bugs where isolates don't start because the
objective C code can't find the callback. This seems to happen more
often on physical devices.

This fixes https://github.com/ryanheise/audio_service/issues/334.