### PR TITLE
Update handlePlatformMessage to stop using deprecated API

### DIFF
--- a/lib/flutter_isolate.dart
+++ b/lib/flutter_isolate.dart
@@ -100,7 +100,7 @@ class FlutterIsolate {
   static get current => _current != null ? _current : FlutterIsolate._();
   static void _isolateInitialize() {
     WidgetsFlutterBinding.ensureInitialized();
-    window.onPlatformMessage = BinaryMessenger.handlePlatformMessage;
+    window.onPlatformMessage = defaultBinaryMessenger.handlePlatformMessage;
 
     StreamSubscription eventSubscription;
     eventSubscription = _event.receiveBroadcastStream().listen((isolateId) {

--- a/lib/flutter_isolate.dart
+++ b/lib/flutter_isolate.dart
@@ -100,7 +100,7 @@ class FlutterIsolate {
   static get current => _current != null ? _current : FlutterIsolate._();
   static void _isolateInitialize() {
     WidgetsFlutterBinding.ensureInitialized();
-    window.onPlatformMessage = BinaryMessages.handlePlatformMessage;
+    window.onPlatformMessage = BinaryMessenger.handlePlatformMessage;
 
     StreamSubscription eventSubscription;
     eventSubscription = _event.receiveBroadcastStream().listen((isolateId) {

--- a/lib/flutter_isolate.dart
+++ b/lib/flutter_isolate.dart
@@ -100,7 +100,7 @@ class FlutterIsolate {
   static get current => _current != null ? _current : FlutterIsolate._();
   static void _isolateInitialize() {
     WidgetsFlutterBinding.ensureInitialized();
-    window.onPlatformMessage = defaultBinaryMessenger.handlePlatformMessage;
+    window.onPlatformMessage = ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage;
 
     StreamSubscription eventSubscription;
     eventSubscription = _event.receiveBroadcastStream().listen((isolateId) {


### PR DESCRIPTION
Fixes https://github.com/rmawatson/flutter_isolate/issues/63.

You'll want to squash this, I was iterating on it in a pretty dumb and sleep-deprived way, so there are 3 commits for a one-line change :|