### PR TITLE
Remove V1 embedding

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:4.1.3'
     }
 }
 

--- a/android/src/main/java/com/rmawatson/flutterisolate/FlutterIsolatePlugin.java
+++ b/android/src/main/java/com/rmawatson/flutterisolate/FlutterIsolatePlugin.java
@@ -118,7 +118,7 @@ public class FlutterIsolatePlugin implements FlutterPlugin, MethodCallHandler, S
 
             queuedIsolates.add(isolate);
 
-            if (queuedIsolates.size() == 1) {// no other pending isolate
+            if (queuedIsolates.size() == 1) { // no other pending isolate
                 startNextIsolate();
             }
         } else if (call.method.equals("kill_isolate")) {
@@ -126,7 +126,6 @@ public class FlutterIsolatePlugin implements FlutterPlugin, MethodCallHandler, S
 
             activeIsolates.get(isolateId).engine.destroy();
             activeIsolates.remove(isolateId);
-
         } else {
             result.notImplemented();
         }

--- a/android/src/main/java/com/rmawatson/flutterisolate/FlutterIsolatePlugin.java
+++ b/android/src/main/java/com/rmawatson/flutterisolate/FlutterIsolatePlugin.java
@@ -2,13 +2,14 @@ package com.rmawatson.flutterisolate;
 
 import android.content.Context;
 
-import java.lang.reflect.InvocationTargetException;
+import androidx.annotation.NonNull;
+
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Queue;
 
-import io.flutter.app.FlutterPluginRegistry;
+import io.flutter.FlutterInjector;
 import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.embedding.engine.dart.DartExecutor;
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
@@ -19,11 +20,7 @@ import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
-import io.flutter.plugin.common.PluginRegistry;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
 import io.flutter.view.FlutterCallbackInformation;
-import io.flutter.view.FlutterMain;
-import io.flutter.view.FlutterNativeView;
 import io.flutter.view.FlutterRunArguments;
 
 /**
@@ -31,7 +28,6 @@ import io.flutter.view.FlutterRunArguments;
  */
 
 class IsolateHolder {
-    FlutterNativeView view;
     FlutterEngine engine;
     String isolateId;
 
@@ -46,67 +42,11 @@ public class FlutterIsolatePlugin implements FlutterPlugin, MethodCallHandler, S
 
     public static final String NAMESPACE = "com.rmawatson.flutterisolate";
 
-    private MethodChannel controlChannel;
     private Queue<IsolateHolder> queuedIsolates;
     private Map<String, IsolateHolder> activeIsolates;
-    static private Class registrant;
     private Context context;
     private FlutterPluginBinding flutterPluginBinding;
 
-
-    private static void registerWithRegistrant(FlutterPluginRegistry registry) {
-        try {
-            Class registrant = FlutterIsolatePlugin.registrant == null ?
-                    Class.forName("io.flutter.plugins.GeneratedPluginRegistrant") :
-                    FlutterIsolatePlugin.registrant;
-            registrant.getMethod("registerWith", PluginRegistry.class).invoke(null, registry);
-        } catch (ClassNotFoundException classNotFoundException) {
-            String error = classNotFoundException.getClass().getSimpleName()
-                    + ": " + classNotFoundException.getMessage() + "\n" +
-                    "Unable to find the default GeneratedPluginRegistrant.";
-            android.util.Log.e("FlutterIsolate", error);
-            return;
-        } catch (NoSuchMethodException noSuchMethodException) {
-            String error = noSuchMethodException.getClass().getSimpleName()
-                    + ": " + noSuchMethodException.getMessage() + "\n" +
-                    "The plugin registrant must provide a static registerWith(FlutterPluginRegistry) method";
-            android.util.Log.e("FlutterIsolate", error);
-            return;
-        } catch (InvocationTargetException invocationException) {
-            Throwable target = invocationException.getTargetException();
-            String error = target.getClass().getSimpleName() + ": " + target.getMessage() + "\n" +
-                    "It is possible the default GeneratedPluginRegistrant is attempting to register\n" +
-                    "a plugin that uses registrar.activity() or a similar method. Flutter Isolates have no\n" +
-                    "access to the activity() from the registrant. If the activity is being use to register\n" +
-                    "a method or event channel, have the plugin use registrar.context() instead. Alternatively\n" +
-                    "use a custom registrant for isolates, that only registers plugins that the isolate needs\n" +
-                    "to use.";
-            android.util.Log.e("FlutterIsolate", error);
-            return;
-        } catch (Exception except) {
-            android.util.Log.e("FlutterIsolate", except.getClass().getSimpleName() + " " + ((InvocationTargetException) except).getTargetException().getMessage());
-        }
-    }
-
-    /* This should be used to provides a custom plugin registrant for any FlutterIsolates that are spawned.
-     * by copying the GeneratedPluginRegistrant provided by flutter call say "IsolatePluginRegistrant", modifying the
-     * list of plugins that are registered (removing the ones you do not want to use from within a plugin) and passing
-     * the class to setCustomIsolateRegistrant in your MainActivity.
-     *
-     * FlutterIsolatePlugin.setCustomIsolateRegistrant(IsolatePluginRegistrant.class);
-     *
-     * The list will have to be manually maintained if plugins are added or removed, as Flutter automatically
-     * regenerates GeneratedPluginRegistrant.
-     */
-    public static void setCustomIsolateRegistrant(Class registrant) {
-        FlutterIsolatePlugin.registrant = registrant;
-    }
-
-    // V1 Plugin Registration
-    public static void registerWith(Registrar registrar) {
-        final FlutterIsolatePlugin plugin = new FlutterIsolatePlugin();
-        plugin.setupChannel(registrar.messenger(), registrar.context());
-    }
 
     // V2 Embedding
     @Override
@@ -116,14 +56,14 @@ public class FlutterIsolatePlugin implements FlutterPlugin, MethodCallHandler, S
     }
 
     @Override
-    public void onDetachedFromEngine(FlutterPluginBinding binding) {
+    public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
         flutterPluginBinding = null;
     }
 
 
     private void setupChannel(BinaryMessenger messenger, Context context) {
         this.context = context;
-        controlChannel = new MethodChannel(messenger, NAMESPACE + "/control");
+        MethodChannel controlChannel = new MethodChannel(messenger, NAMESPACE + "/control");
         queuedIsolates = new LinkedList<>();
         activeIsolates = new HashMap<>();
 
@@ -132,40 +72,28 @@ public class FlutterIsolatePlugin implements FlutterPlugin, MethodCallHandler, S
 
 
     private void startNextIsolate() {
-
         IsolateHolder isolate = queuedIsolates.peek();
 
-        FlutterMain.ensureInitializationComplete(context, null);
+        FlutterInjector.instance().flutterLoader().ensureInitializationComplete(context, null);
 
-        if (flutterPluginBinding == null)
-            isolate.view = new FlutterNativeView(context, true);
-        else
-            isolate.engine = new FlutterEngine(context);
-
+        isolate.engine = new FlutterEngine(context);
 
         FlutterCallbackInformation cbInfo = FlutterCallbackInformation.lookupCallbackInformation(isolate.entryPoint);
         FlutterRunArguments runArgs = new FlutterRunArguments();
 
-        runArgs.bundlePath = FlutterMain.findAppBundlePath(context);
+        runArgs.bundlePath = FlutterInjector.instance().flutterLoader().findAppBundlePath();
         runArgs.libraryPath = cbInfo.callbackLibraryPath;
         runArgs.entrypoint = cbInfo.callbackName;
 
-        if (flutterPluginBinding == null) {
-            isolate.controlChannel = new MethodChannel(isolate.view, NAMESPACE + "/control");
-            isolate.startupChannel = new EventChannel(isolate.view, NAMESPACE + "/event");
-        } else {
-            isolate.controlChannel = new MethodChannel(isolate.engine.getDartExecutor().getBinaryMessenger(), NAMESPACE + "/control");
-            isolate.startupChannel = new EventChannel(isolate.engine.getDartExecutor().getBinaryMessenger(), NAMESPACE + "/event");
-        }
+        isolate.controlChannel = new MethodChannel(isolate.engine.getDartExecutor().getBinaryMessenger(), NAMESPACE + "/control");
+        isolate.startupChannel = new EventChannel(isolate.engine.getDartExecutor().getBinaryMessenger(), NAMESPACE + "/event");
+
         isolate.startupChannel.setStreamHandler(this);
         isolate.controlChannel.setMethodCallHandler(this);
-        if (flutterPluginBinding == null) {
-            registerWithRegistrant(isolate.view.getPluginRegistry());
-            isolate.view.runFromBundle(runArgs);
-        } else {
-            DartExecutor.DartCallback dartCallback = new DartExecutor.DartCallback(context.getAssets(), runArgs.bundlePath, cbInfo);
-            isolate.engine.getDartExecutor().executeDartCallback(dartCallback);
-        }
+
+        DartExecutor.DartCallback dartCallback = new DartExecutor.DartCallback(context.getAssets(), runArgs.bundlePath, cbInfo);
+        isolate.engine.getDartExecutor().executeDartCallback(dartCallback);
+
     }
 
     @Override
@@ -191,7 +119,7 @@ public class FlutterIsolatePlugin implements FlutterPlugin, MethodCallHandler, S
     }
 
     @Override
-    public void onMethodCall(MethodCall call, Result result) {
+    public void onMethodCall(MethodCall call, @NonNull Result result) {
         if (call.method.equals("spawn_isolate")) {
 
             IsolateHolder isolate = new IsolateHolder();
@@ -208,10 +136,7 @@ public class FlutterIsolatePlugin implements FlutterPlugin, MethodCallHandler, S
 
             String isolateId = call.argument("isolate_id");
 
-            if (activeIsolates.get(isolateId).engine == null)
-                activeIsolates.get(isolateId).view.destroy();
-            else
-                activeIsolates.get(isolateId).engine.destroy();
+            activeIsolates.get(isolateId).engine.destroy();
             activeIsolates.remove(isolateId);
 
         } else {

--- a/android/src/main/java/com/rmawatson/flutterisolate/FlutterIsolatePlugin.java
+++ b/android/src/main/java/com/rmawatson/flutterisolate/FlutterIsolatePlugin.java
@@ -46,7 +46,6 @@ public class FlutterIsolatePlugin implements FlutterPlugin, MethodCallHandler, S
     private Map<String, IsolateHolder> activeIsolates;
     private Context context;
 
-    // V2 Embedding
     @Override
     public void onAttachedToEngine(FlutterPluginBinding binding) {
         setupChannel(binding.getBinaryMessenger(), binding.getApplicationContext());
@@ -56,7 +55,6 @@ public class FlutterIsolatePlugin implements FlutterPlugin, MethodCallHandler, S
     public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
     }
 
-
     private void setupChannel(BinaryMessenger messenger, Context context) {
         this.context = context;
         MethodChannel controlChannel = new MethodChannel(messenger, NAMESPACE + "/control");
@@ -65,7 +63,6 @@ public class FlutterIsolatePlugin implements FlutterPlugin, MethodCallHandler, S
 
         controlChannel.setMethodCallHandler(this);
     }
-
 
     private void startNextIsolate() {
         IsolateHolder isolate = queuedIsolates.peek();
@@ -89,12 +86,10 @@ public class FlutterIsolatePlugin implements FlutterPlugin, MethodCallHandler, S
 
         DartExecutor.DartCallback dartCallback = new DartExecutor.DartCallback(context.getAssets(), runArgs.bundlePath, cbInfo);
         isolate.engine.getDartExecutor().executeDartCallback(dartCallback);
-
     }
 
     @Override
     public void onListen(Object o, EventChannel.EventSink sink) {
-
         IsolateHolder isolate = queuedIsolates.remove();
         sink.success(isolate.isolateId);
         sink.endOfStream();
@@ -104,20 +99,18 @@ public class FlutterIsolatePlugin implements FlutterPlugin, MethodCallHandler, S
         isolate.startupChannel = null;
         isolate.result = null;
 
-        if (queuedIsolates.size() != 0)
+        if (queuedIsolates.size() != 0) {
             startNextIsolate();
-
+        }
     }
 
     @Override
     public void onCancel(Object o) {
-
     }
 
     @Override
     public void onMethodCall(MethodCall call, @NonNull Result result) {
         if (call.method.equals("spawn_isolate")) {
-
             IsolateHolder isolate = new IsolateHolder();
             isolate.entryPoint = call.argument("entry_point");
             isolate.isolateId = call.argument("isolate_id");
@@ -125,11 +118,10 @@ public class FlutterIsolatePlugin implements FlutterPlugin, MethodCallHandler, S
 
             queuedIsolates.add(isolate);
 
-            if (queuedIsolates.size() == 1) // no other pending isolate
+            if (queuedIsolates.size() == 1) {// no other pending isolate
                 startNextIsolate();
-
+            }
         } else if (call.method.equals("kill_isolate")) {
-
             String isolateId = call.argument("isolate_id");
 
             activeIsolates.get(isolateId).engine.destroy();

--- a/android/src/main/java/com/rmawatson/flutterisolate/FlutterIsolatePlugin.java
+++ b/android/src/main/java/com/rmawatson/flutterisolate/FlutterIsolatePlugin.java
@@ -45,19 +45,15 @@ public class FlutterIsolatePlugin implements FlutterPlugin, MethodCallHandler, S
     private Queue<IsolateHolder> queuedIsolates;
     private Map<String, IsolateHolder> activeIsolates;
     private Context context;
-    private FlutterPluginBinding flutterPluginBinding;
-
 
     // V2 Embedding
     @Override
     public void onAttachedToEngine(FlutterPluginBinding binding) {
-        flutterPluginBinding = binding;
         setupChannel(binding.getBinaryMessenger(), binding.getApplicationContext());
     }
 
     @Override
     public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
-        flutterPluginBinding = null;
     }
 
 

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:4.1.3'
     }
 }
 

--- a/example/ios/Flutter/Debug.xcconfig
+++ b/example/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/example/ios/Flutter/Release.xcconfig
+++ b/example/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
     sdk: flutter
   flutter_isolate:
     path: ../
-  path_provider: ^2.0.0
+  path_provider: ^2.0.1
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  uuid: ^3.0.0
+  uuid: ^3.0.3
 # For information on the generic Dart part of this file, see the
 # following page: https://www.dartlang.org/tools/pub/pubspec
 


### PR DESCRIPTION
Fixes #68 
After migrating to null-safety embedding v1 isn't used anymore.
This also updates some other deprecated functions.