### PR TITLE
fix onListen for 0 queued isolates

### DIFF
--- a/android/src/main/java/com/rmawatson/flutterisolate/FlutterIsolatePlugin.java
+++ b/android/src/main/java/com/rmawatson/flutterisolate/FlutterIsolatePlugin.java
@@ -138,14 +138,17 @@ public class FlutterIsolatePlugin implements FlutterPlugin, MethodCallHandler, S
 
     @Override
     public void onListen(Object o, EventChannel.EventSink sink) {
-        IsolateHolder isolate = queuedIsolates.remove();
-        sink.success(isolate.isolateId);
-        sink.endOfStream();
-        activeIsolates.put(isolate.isolateId, isolate);
+        if (queuedIsolates.size() != 0) {
+            IsolateHolder isolate = queuedIsolates.remove();
+        
+            sink.success(isolate.isolateId);
+            sink.endOfStream();
+            activeIsolates.put(isolate.isolateId, isolate);
 
-        isolate.result.success(null);
-        isolate.startupChannel = null;
-        isolate.result = null;
+            isolate.result.success(null);
+            isolate.startupChannel = null;
+            isolate.result = null;
+        }
 
         if (queuedIsolates.size() != 0) {
             startNextIsolate();

--- a/ios/Classes/FlutterIsolatePlugin.m
+++ b/ios/Classes/FlutterIsolatePlugin.m
@@ -143,14 +143,16 @@ static NSString* _isolatePluginRegistrantClassName;
 
     IsolateHolder* isolate = _queuedIsolates.firstObject;
 
-    sink(isolate.isolateId);
-    sink(FlutterEndOfEventStream);
-    _activeIsolates[isolate.isolateId] = isolate;
-    [_queuedIsolates removeObject:isolate];
+    if (isolate != nil) {
+        sink(isolate.isolateId);
+        sink(FlutterEndOfEventStream);
+        _activeIsolates[isolate.isolateId] = isolate;
+        [_queuedIsolates removeObject:isolate];
 
-    isolate.result(@(YES));
-    isolate.startupChannel = nil;
-    isolate.result = nil;
+        isolate.result(@(YES));
+        isolate.startupChannel = nil;
+        isolate.result = nil;
+    }
 
     if (_queuedIsolates.count != 0)
         [self startNextIsolate];


### PR DESCRIPTION
Fix `onListen` when there are no queued isolates. This can happen for example when hot-reloading.