### PR TITLE
Add priority to kill()

### DIFF
--- a/lib/flutter_isolate.dart
+++ b/lib/flutter_isolate.dart
@@ -83,9 +83,9 @@ class FlutterIsolate {
   /// even after user code has completed. Thus they must be explicitly
   /// terminate using kill if you wish to dispose of them after you have
   /// finished. This should cleanup the native components backing the isolates.
-  void kill() => _isolateId != null
+  void kill({int priority = beforeNextEvent}) => _isolateId != null
       ? _control.invokeMethod("kill_isolate", {"isolate_id": _isolateId})
-      : Isolate.current.kill();
+      : Isolate.current.kill(priority);
 
   String? _isolateId;
   static FlutterIsolate? _current;


### PR DESCRIPTION
The idea of killing the isolates immediately came up in the issue queue of `isolate_handler`: https://github.com/deakjahn/isolate_handler/issues/25

As I mentioned there, we can't call what `flutter_isolate` doesn't expose. Adding this optional parameter seems to be a very simple solution that, being optional, doesn't mean any real change for you but can provide both your direct users and ours to pass a priority along.