### PR TITLE
Add compute-like function to simplify working with flutter_isolate

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ FlutterIsolate allows creation of an Isolate in flutter that is able to use flut
 | FlutterIsolate.kill()             | :white_check_mark: |  :white_check_mark:  | kills a an isolate |
 | FlutterIsolate.killAll()             | :white_check_mark: |  :white_check_mark:  | kills all currently running  isolates |
 | FlutterIsolate.runningIsolates             | :white_check_mark: |  :white_check_mark:  | returns the IDs associated with all currently running isolates |
+| flutterCompute(callback,message)  | :white_check_mark: |  :white_check_mark:  | spawns a new FlutterIsolate, runs callback and returns the returned value |
 
 ### Usage
 
@@ -47,6 +48,18 @@ void main() async {
   runApp(MyApp());
 }
 ...
+```
+
+```dart
+Future<int> expansiveWork(int arg) async {
+  int result;
+  // lots of calculations
+  return result;
+}
+
+Future<int> doExpansiveWorkInBackground() async {
+  return await flutterCompute(expansiveWork, arg);
+}
 ```
 
 See [example/lib/main.dart](https://github.com/rmawatson/flutter_isolate/blob/master/example/lib/main.dart) for example usage with the [flutter_downloader plugin](https://pub.dev/packages/flutter_downloader).

--- a/README.md
+++ b/README.md
@@ -51,13 +51,13 @@ void main() async {
 ```
 
 ```dart
-Future<int> expansiveWork(int arg) async {
+Future<int> expensiveWork(int arg) async {
   int result;
   // lots of calculations
   return result;
 }
 
-Future<int> doExpansiveWorkInBackground() async {
+Future<int> doExpensiveWorkInBackground() async {
   return await flutterCompute(expansiveWork, arg);
 }
 ```

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -31,6 +31,12 @@ void isolate1(String arg) async {
       Duration(seconds: 1), (timer) => print("Timer Running From Isolate 1"));
 }
 
+void computeFunction(String arg) async {
+  getTemporaryDirectory().then((dir) {
+    print("Temporary directory in compute function : $dir with arg $arg");
+  });
+}
+
 void main() async {
   runApp(MyApp());
 }
@@ -107,7 +113,12 @@ class AppWidget extends StatelessWidget {
         child: Text('Kill all running isolates'),
         onPressed: () async {
           await FlutterIsolate.killAll();
-        },)
+        },),
+      ElevatedButton(
+        child: Text('Run in compute function'),
+        onPressed: () async {
+          await flutterCompute(computeFunction, "foo");
+        },),
     ]);
   }
 }

--- a/lib/flutter_isolate.dart
+++ b/lib/flutter_isolate.dart
@@ -6,6 +6,8 @@ import 'package:uuid/uuid.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
+export 'src/compute.dart';
+
 class FlutterIsolate {
   /// Control port used to send control messages to the isolate.
   SendPort? controlPort;

--- a/lib/src/compute.dart
+++ b/lib/src/compute.dart
@@ -1,0 +1,78 @@
+import 'dart:async';
+import 'dart:isolate';
+import 'dart:ui';
+
+import 'package:flutter_isolate/flutter_isolate.dart';
+
+/// A function that spawns a flutter isolate and runs the provided [callback] on
+/// that isolate, passes it the provided [message], and (eventually) returns the
+/// value returned by [callback].
+///
+/// Since [callback] needs to be passed between isolates, it must be a top-level
+/// function or a static method.
+///
+/// Both the return type and the [message] type must be supported by
+/// [SendPort.send] stated in
+/// https://api.dart.dev/stable/dart-isolate/SendPort/send.html
+Future<T> flutterCompute<T, U>(
+    FutureOr<T> Function(U message) callback, U message) async {
+  final callbackHandle =
+      PluginUtilities.getCallbackHandle(callback)!.toRawHandle();
+  final completer = Completer<dynamic>();
+  final port = RawReceivePort();
+  port.handler = (dynamic response) {
+    port.close();
+    completer.complete(response);
+  };
+
+  FlutterIsolate? isolate;
+  try {
+    isolate = await FlutterIsolate.spawn(_isolateMain, {
+      "callback": callbackHandle,
+      "port": port.sendPort,
+      "message": message,
+    });
+  } catch (_) {
+    port.close();
+    isolate?.kill();
+    rethrow;
+  }
+  final response = await completer.future;
+  isolate.kill();
+
+  if (response == null) {
+    throw RemoteError("Isolate exited without result or error.", "");
+  }
+  if (response["status"] == _Status.ok.index) {
+    return response["result"] as T;
+  } else {
+    await Future<Never>.error(
+      RemoteError(response["error"], response["stackTrace"]),
+    );
+  }
+}
+
+enum _Status {
+  ok,
+  error,
+}
+
+Future<void> _isolateMain(Map<String, dynamic> config) async {
+  final port = config["port"] as SendPort;
+  try {
+    final callbackHandle = CallbackHandle.fromRawHandle(config["callback"]);
+    final callback = PluginUtilities.getCallbackFromHandle(callbackHandle);
+    final message = config["message"];
+    final result = await callback!(message);
+    port.send({
+      "status": _Status.ok.index,
+      "result": result,
+    });
+  } catch (e, stackTrace) {
+    port.send({
+      "status": _Status.error.index,
+      "error": e.toString(),
+      "stackTrace": stackTrace.toString(),
+    });
+  }
+}


### PR DESCRIPTION
compute() provides a simple way to work with regular isolates without needing to understand and work with the underlying isolate API. This PR implements a new function, flutterCompute(), that works similar to compute(), but for flutter_isolate.