### PR TITLE
Fixing release and obfuscated build issues for flutter 3.x.x

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:flutter_isolate/flutter_isolate.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:flutter_downloader/flutter_downloader.dart';
 
+@pragma('vm:entry-point')
 void isolate2(String arg) {
   getTemporaryDirectory().then((dir) async {
     print("isolate2 temporary directory: $dir");
@@ -21,6 +22,7 @@ void isolate2(String arg) {
       Duration(seconds: 1), (timer) => print("Timer Running From Isolate 2"));
 }
 
+@pragma('vm:entry-point')
 void isolate1(String arg) async {
   await FlutterIsolate.spawn(isolate2, "hello2");
 

--- a/lib/flutter_isolate.dart
+++ b/lib/flutter_isolate.dart
@@ -32,7 +32,7 @@ class FlutterIsolate {
         setupReceivePort.sendPort, isolateId);
     late StreamSubscription setupSubscription;
     setupSubscription = setupReceivePort.listen((data) {
-      final portSetup = (data as List<Capability?>);
+      final portSetup = (data as List<dynamic>);
       final setupPort = portSetup[0] as SendPort;
       final remoteIsolate = FlutterIsolate._(
           isolateId, portSetup[1] as SendPort?, portSetup[2], portSetup[3]);
@@ -111,6 +111,7 @@ class FlutterIsolate {
 
   static FlutterIsolate get current =>
       _current != null ? _current! : FlutterIsolate._();
+  @pragma('vm:entry-point')
   static void _isolateInitialize() {
     WidgetsFlutterBinding.ensureInitialized();
 
@@ -121,7 +122,7 @@ class FlutterIsolate {
           IsolateNameServer.lookupPortByName(_current!._isolateId!)!;
       final setupReceivePort = ReceivePort();
       IsolateNameServer.removePortNameMapping(_current!._isolateId!);
-      sendPort.send(<Capability?>[
+      sendPort.send(<dynamic>[
         setupReceivePort.sendPort,
         Isolate.current.controlPort,
         Isolate.current.pauseCapability,
@@ -144,4 +145,5 @@ class FlutterIsolate {
   }
 }
 
+@pragma('vm:entry-point')
 void _flutterIsolateEntryPoint() => FlutterIsolate._isolateInitialize();


### PR DESCRIPTION
This PR fixes release and obfuscation issues that were happending since flutter 2.8.x.

Please note that also example package was modified in order to promote the usage of 
```
@pragma('vm:entry-point')
```
for every top level or static method in order to avoid obfuscation.

Library also failed to send List<Capability?> arguments through ports, likely because class names could not be resolved internally by dart engine. And since only basic types should be sent trough ports, List<dynamic> suits and works instead as well.

Please review and merge this ASAP as a lot of projects depend on this.