### PR TITLE
[Fix] ClassCastException for ioslate entry point

### DIFF
--- a/android/src/main/java/com/rmawatson/flutterisolate/FlutterIsolatePlugin.java
+++ b/android/src/main/java/com/rmawatson/flutterisolate/FlutterIsolatePlugin.java
@@ -165,7 +165,14 @@ public class FlutterIsolatePlugin implements FlutterPlugin, MethodCallHandler, S
     public void onMethodCall(MethodCall call, @NonNull Result result) {
         if (call.method.equals("spawn_isolate")) {
             IsolateHolder isolate = new IsolateHolder();
-            isolate.entryPoint = call.argument("entry_point");
+            final Object entryPoint = call.argument("entry_point");
+            if(entryPoint instanceof Long) {
+                isolate.entryPoint = (Long) entryPoint;
+            }
+
+            if(entryPoint instanceof Integer) {
+                isolate.entryPoint = Long.valueOf((Integer) entryPoint);
+            }
             isolate.isolateId = call.argument("isolate_id");
             isolate.result = result;
 


### PR DESCRIPTION
Getting Exceptions from Crashlytics in our Production App.
`Non-fatal Exception: io.flutter.plugins.firebase.crashlytics.FlutterError
PlatformException(error, java.lang.Integer cannot be cast to java.lang.Long, null, java.lang.ClassCastException: java.lang.Integer cannot be cast to java.lang.Long at f.p.a.a.onMethodCall(FlutterIsolatePlugin.java:3) at io.flutter.plugin.common.MethodChannel$IncomingMethodCallHandler.onMessage(MethodChannel.java:2) at io.flutter.embedding.engine.dart.DartMessenger.handleMessageFromDart(DartMessenger.java:4) at io.flutter.embedding.engine.FlutterJNI.handlePlatformMessage(FlutterJNI.java:2) at android.os.MessageQueue.nativePollOnce(Native Method) at android.os.MessageQueue.next(MessageQueue.java:328) at android.os.Looper.loop(Looper.java:164) at android.app.ActivityThread.main(ActivityThread.java:5765) at java.lang.reflect.Method.invoke(Native Method) at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:789) at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:679) ). Error thrown null.`
after do some testing. i suspect its due to the dart level int been passed to native java been consider as Integer in some cases:
0x0fffffff will be Integer for Java
0xffffffff will be Long for Java
This PR added a type check and casting for ioslate entry point.