### PR TITLE
Increase supported uuid version range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.5
+* Increase supported `uuid` version range
+
 ## 2.0.4
 * Fix crashes in release mode when using new flutterCompute method
 * Migrate Android jCenter to Maven Central

--- a/lib/flutter_isolate.dart
+++ b/lib/flutter_isolate.dart
@@ -26,7 +26,7 @@ class FlutterIsolate {
       void entryPoint(T message), T message) async {
     final userEntryPointId =
         PluginUtilities.getCallbackHandle(entryPoint)!.toRawHandle();
-    final isolateId = Uuid().v4();
+    final isolateId = const Uuid().v4();
     final isolateResult = Completer<FlutterIsolate>();
     final setupReceivePort = ReceivePort();
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_isolate
 description: FlutterIsolate provides a way to launch dart isolate in flutter that work with flutter plugins.
-version: 2.0.4
+version: 2.0.5
 homepage: https://github.com/rmawatson/flutter_isolate
 
 environment:
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  uuid: ^3.0.3
+  uuid: ">=3.0.3 <5.0.0"
 # For information on the generic Dart part of this file, see the
 # following page: https://www.dartlang.org/tools/pub/pubspec
 


### PR DESCRIPTION
* closes #143 

The `v4()` function has not changed so this is not breaking.
Additionally use `const Uuid()` which was added in `v3.0.0-nullsafety.1` so should be safe.
